### PR TITLE
Add config commands and default file output setting

### DIFF
--- a/gh_pr_rev_md/config.py
+++ b/gh_pr_rev_md/config.py
@@ -7,6 +7,7 @@ This module loads configuration following the XDG Base Directory specification:
 Config keys (all optional):
 - token: str
 - include_resolved: bool
+- include_outdated: bool
 - output: bool
 - output_file: str
 """
@@ -79,7 +80,13 @@ def load_config() -> Dict[str, Any]:
     Later files override earlier ones. Only known keys are kept.
     """
     merged: Dict[str, Any] = {}
-    allowed_keys = {"token", "include_resolved", "output", "output_file"}
+    allowed_keys = {
+        "token",
+        "include_resolved",
+        "include_outdated",
+        "output",
+        "output_file",
+    }
 
     for path in _candidate_files():
         if path.is_file():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
-"""Comprehensive tests for CLI functionality, focusing on file output features."""
+"""Comprehensive tests for CLI functionality."""
 
 import pytest
-import subprocess
 from click.testing import CliRunner
 from unittest import mock
 from pathlib import Path
@@ -36,28 +35,19 @@ def mock_github_client():
                 "path": "file1.py",
                 "diff_hunk": "@@ -1,3 +1,3 @@",
                 "line": 10,
-            },
-            {
-                "id": 2,
-                "user": {"login": "anotheruser"},
-                "body": "Test comment 2",
-                "created_at": "2023-01-01T11:00:00Z",
-                "updated_at": "2023-01-01T11:00:00Z",
-                "path": "file2.js",
-                "diff_hunk": "@@ -5,2 +5,3 @@",
-                "line": 20,
-            },
+            }
         ]
+        mock_instance.get_authenticated_user.return_value = "testuser"
         yield mock_instance
 
 
 @pytest.fixture
 def mock_formatter():
     """Mocks the format_comments_as_markdown function."""
-    with mock.patch("gh_pr_rev_md.cli.format_comments_as_markdown") as mock_formatter_func:
-        mock_formatter_func.return_value = (
-            "# PR #123 Review Comments\n\nMocked markdown output"
-        )
+    with mock.patch(
+        "gh_pr_rev_md.cli.format_comments_as_markdown"
+    ) as mock_formatter_func:
+        mock_formatter_func.return_value = "Mocked markdown output"
         yield mock_formatter_func
 
 
@@ -70,703 +60,184 @@ def mock_datetime_now():
         yield mock_dt
 
 
-# --- Tests for parse_pr_url function ---
+@pytest.fixture
+def mock_config_file(tmp_path, monkeypatch):
+    """Fixture to create a temporary config file and set XDG_CONFIG_HOME."""
+    xdg_home = tmp_path / ".config"
+    app_dir = xdg_home / "gh-pr-rev-md"
+    app_dir.mkdir(parents=True)
+    config_file = app_dir / "config.yaml"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+    return config_file
+
+
+# --- Tests for helper functions ---
 
 
 def test_parse_pr_url_valid():
     """Test that parse_pr_url correctly extracts components from valid URLs."""
-    test_cases = [
-        ("https://github.com/owner/repo/pull/123", ("owner", "repo", 123)),
-        (
-            "https://github.com/microsoft/vscode/pull/999999",
-            ("microsoft", "vscode", 999999),
-        ),
-        ("https://github.com/a/b/pull/1", ("a", "b", 1)),
-        (
-            "https://github.com/owner-dash/repo_under/pull/456",
-            ("owner-dash", "repo_under", 456),
-        ),
-    ]
-
-    for url, expected in test_cases:
-        owner, repo, pr_number = cli.parse_pr_url(url)
-        assert (owner, repo, pr_number) == expected
+    owner, repo, pr_number = cli.parse_pr_url(
+        "https://github.com/owner/repo/pull/123"
+    )
+    assert (owner, repo, pr_number) == ("owner", "repo", 123)
 
 
-@pytest.mark.parametrize(
-    "invalid_url",
-    [
-        "http://github.com/owner/repo/pull/123",  # HTTP instead of HTTPS
-        "https://github.com/owner/repo/pull/",  # Missing PR number
-        "https://github.com/owner/pull/123",  # Missing repo
-        "https://github.com/owner/repo/issues/123",  # Issues instead of pull
-        "https://gitlab.com/owner/repo/pull/123",  # Wrong domain
-        "invalid-url",  # Completely invalid
-        "",  # Empty string
-        "https://github.com/owner/repo/pull/abc",  # Non-numeric PR number
-    ],
-)
-def test_parse_pr_url_invalid(invalid_url):
+def test_parse_pr_url_invalid(runner):
     """Test that parse_pr_url raises click.BadParameter for invalid URLs."""
     with pytest.raises(cli.click.BadParameter):
-        cli.parse_pr_url(invalid_url)
-
-
-# --- Tests for generate_filename function ---
+        cli.parse_pr_url("invalid-url")
 
 
 def test_generate_filename_format(mock_datetime_now):
     """Test that generate_filename produces the expected format."""
     filename = cli.generate_filename("owner", "repo", 123)
-    expected = "owner-repo-20230115-123045-pr123.md"
-    assert filename == expected
+    assert filename == "owner-repo-20230115-123045-pr123.md"
 
 
-def test_generate_filename_edge_cases(mock_datetime_now):
-    """Test generate_filename with edge case inputs."""
-    test_cases = [
-        ("", "repo", 123, "-repo-20230115-123045-pr123.md"),
-        ("owner", "", 456, "owner--20230115-123045-pr456.md"),
-        ("UPPER", "MixedCase", 1, "UPPER-MixedCase-20230115-123045-pr1.md"),
-        ("owner.dot", "repo@symbol", 0, "owner.dot-repo@symbol-20230115-123045-pr0.md"),
-    ]
-
-    for owner, repo, pr_number, expected in test_cases:
-        filename = cli.generate_filename(owner, repo, pr_number)
-        assert filename == expected
+# --- Tests for 'fetch' command ---
 
 
-# --- Tests for main CLI command file output functionality ---
+class TestFetchCommand:
+    """Tests for the 'fetch' subcommand."""
 
+    def test_fetch_output_flag(
+        self, runner, mock_github_client, mock_formatter, mock_datetime_now
+    ):
+        """Test 'fetch --output' creates file with auto-generated name."""
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli.main,
+                ["fetch", "https://github.com/owner/repo/pull/123", "--output"],
+            )
+            assert result.exit_code == 0
+            expected_filename = "owner-repo-20230115-123045-pr123.md"
+            assert Path(expected_filename).exists()
+            assert "Output saved to" in result.output
 
-def test_main_output_flag_auto_filename(
-    runner, mock_github_client, mock_formatter, mock_datetime_now
-):
-    """Test --output flag creates file with auto-generated filename."""
-    with runner.isolated_filesystem():
+    def test_fetch_output_file_flag(self, runner, mock_github_client, mock_formatter):
+        """Test 'fetch --output-file' creates file with custom name."""
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli.main,
+                [
+                    "fetch",
+                    "https://github.com/owner/repo/pull/123",
+                    "--output-file",
+                    "custom.md",
+                ],
+            )
+            assert result.exit_code == 0
+            assert Path("custom.md").exists()
+
+    def test_fetch_no_output_flags_stdout(
+        self, runner, mock_github_client, mock_formatter
+    ):
+        """Test fetch output goes to stdout when no output flags are provided."""
         result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
-                "--output",
-            ],
+            cli.main, ["fetch", "https://github.com/owner/repo/pull/123"]
         )
-
         assert result.exit_code == 0
-        expected_filename = "owner-repo-20230115-123045-pr123.md"
-        assert Path(expected_filename).exists()
-
-        content = Path(expected_filename).read_text(encoding="utf-8")
-        assert content == "# PR #123 Review Comments\n\nMocked markdown output"
-
-        assert "Output saved to:" in result.output
-        assert expected_filename in result.output
-
-
-def test_main_output_file_flag_custom_filename(
-    runner, mock_github_client, mock_formatter
-):
-    """Test --output-file flag creates file with custom filename."""
-    with runner.isolated_filesystem():
-        custom_filename = "my_custom_pr_review.md"
-        result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
-                "--output-file",
-                custom_filename,
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert Path(custom_filename).exists()
-
-        content = Path(custom_filename).read_text(encoding="utf-8")
-        assert content == "# PR #123 Review Comments\n\nMocked markdown output"
-
-        assert "Output saved to:" in result.output
-        assert custom_filename in result.output
-
-
-def test_main_output_file_precedence(
-    runner, mock_github_client, mock_formatter, mock_datetime_now
-):
-    """Test that --output-file takes precedence over --output when both are provided."""
-    with runner.isolated_filesystem():
-        custom_filename = "explicit_file.md"
-        auto_filename = "owner-repo-20230115-123045-pr123.md"
-
-        result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
-                "--output",
-                "--output-file",
-                custom_filename,
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert Path(custom_filename).exists()
-        assert not Path(auto_filename).exists()  # Auto-generated file should NOT exist
-
-        assert custom_filename in result.output
-        assert auto_filename not in result.output
-
-
-def test_main_no_output_flags_stdout(runner, mock_github_client, mock_formatter):
-    """Test that output goes to stdout when no output flags are provided."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli.main,
-            ["https://github.com/owner/repo/pull/123", "--token", "test_token"],
-        )
-
-        assert result.exit_code == 0
-        # Verify no files were created
-        assert list(Path(".").glob("*.md")) == []
-
-        # Verify output contains the markdown content directly
-        assert "# PR #123 Review Comments" in result.output
         assert "Mocked markdown output" in result.output
 
-
-def test_main_file_write_permission_error(runner, mock_github_client, mock_formatter):
-    """Test error handling when file write fails due to permissions."""
-    with runner.isolated_filesystem():
-        # Create a directory with the same name as our intended file
-        restricted_filename = "restricted.md"
-        Path(restricted_filename).mkdir()  # This will cause write to fail
-
-        result = runner.invoke(
+    def test_fetch_include_flags(self, runner, mock_github_client):
+        """Test that --include-resolved and --include-outdated flags are passed."""
+        runner.invoke(
             cli.main,
             [
+                "fetch",
                 "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
-                "--output-file",
-                restricted_filename,
-            ],
-        )
-
-        assert result.exit_code == 1
-        assert "Error writing to file" in result.output
-        assert restricted_filename in result.output
-
-
-def test_main_file_write_nested_directory(runner, mock_github_client, mock_formatter):
-    """Test file output to nested directory path."""
-    with runner.isolated_filesystem():
-        nested_filename = "nested/dir/output.md"
-
-        result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
-                "--output-file",
-                nested_filename,
-            ],
-        )
-
-        # This should fail because parent directories don't exist
-        assert result.exit_code == 1
-        assert "Error writing to file" in result.output
-
-
-def test_main_include_flags_integration(
-    runner, mock_github_client, mock_formatter
-):
-    """Test that --include-resolved and --include-outdated flags work."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
                 "--include-resolved",
                 "--include-outdated",
-                "--output",
             ],
         )
-
-        assert result.exit_code == 0
-        # Verify flags were passed to GitHub client
         mock_github_client.get_pr_review_comments.assert_called_once_with(
             "owner", "repo", 123, True, True
         )
 
-
-def test_main_utf8_encoding(runner, mock_github_client, mock_formatter):
-    """Test that files are written with UTF-8 encoding."""
-    # Mock formatter to return content with unicode characters
-    mock_formatter.return_value = "# PR Review\n\n👍 Looks good! 中文测试"
-
-    with runner.isolated_filesystem():
+    def test_fetch_api_error(self, runner, mock_github_client):
+        """Test 'fetch' handles GitHub API errors gracefully."""
+        mock_github_client.get_pr_review_comments.side_effect = (
+            github_client.GitHubAPIError("API Error")
+        )
         result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
-                "--output-file",
-                "unicode_test.md",
-            ],
+            cli.main, ["fetch", "https://github.com/owner/repo/pull/123"]
         )
-
-        assert result.exit_code == 0
-        content = Path("unicode_test.md").read_text(encoding="utf-8")
-        assert "👍" in content
-        assert "中文测试" in content
-
-
-# --- Tests for error conditions ---
-
-
-def test_main_no_token_warning_allows_run(runner, monkeypatch):
-    """When no token is provided, CLI warns but proceeds (unauthenticated)."""
-    # Prevent real network calls by mocking GitHubClient.get_pr_review_comments
-    from gh_pr_rev_md import cli as cli_module
-
-    monkeypatch.setattr(
-        cli_module.GitHubClient,
-        "get_pr_review_comments",
-        lambda self, owner, repo, pr, include_outdated=None, include_resolved=None: [],
-        raising=True,
-    )
-
-    # Ensure no token is set via environment variable or config file
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.setattr("gh_pr_rev_md.cli.load_config", lambda: {})
-
-    result = runner.invoke(cli.main, ["https://github.com/owner/repo/pull/123"])
-
-    assert result.exit_code == 0
-    # In Click testing, stderr is often captured along with stdout in result.output
-    assert "Unauthenticated requests are limited" in result.output
-
-
-def test_main_invalid_url_error(runner):
-    """Test CLI exits with error for invalid PR URL."""
-    result = runner.invoke(cli.main, ["invalid-url", "--token", "test_token"])
-
-    assert result.exit_code == 1
-    assert "Invalid GitHub PR URL format" in result.output
-
-
-def test_main_github_api_error(runner, mock_github_client):
-    """Test CLI handles GitHub API errors gracefully."""
-    mock_github_client.get_pr_review_comments.side_effect = (
-        github_client.GitHubAPIError("PR not found")
-    )
-
-    result = runner.invoke(
-        cli.main, ["https://github.com/owner/repo/pull/123", "--token", "test_token"]
-    )
-
-    assert result.exit_code == 1
-    assert "Error fetching data from GitHub: PR not found" in result.output
-
-
-def test_main_github_api_generic_error(runner, mock_github_client):
-    """Test CLI handles unexpected exceptions during API calls."""
-    mock_github_client.get_pr_review_comments.side_effect = Exception("Network timeout")
-
-    result = runner.invoke(
-        cli.main, ["https://github.com/owner/repo/pull/123", "--token", "test_token"]
-    )
-
-    assert result.exit_code == 1
-    assert "An unexpected error occurred: Network timeout" in result.output
-
-
-def test_main_absolute_path_reporting(runner, mock_github_client, mock_formatter):
-    """Test that success message shows absolute path of created file."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "test_token",
-                "--output-file",
-                "test.md",
-            ],
-        )
-
-        assert result.exit_code == 0
-        # Check that absolute path is shown in output
-        assert str(Path("test.md").absolute()) in result.output
-
-
-def test_config_applies_when_cli_missing(
-    runner, mock_github_client, mock_formatter, tmp_path, monkeypatch
-):
-    """If CLI flags are not provided, values from XDG YAML config are used."""
-    xdg_home = tmp_path / ".config"
-    app_dir = xdg_home / "gh-pr-rev-md"
-    app_dir.mkdir(parents=True)
-    (app_dir / "config.yaml").write_text(
-        """
-output_file: config_output.md
-""",
-        encoding="utf-8",
-    )
-
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert Path("config_output.md").exists()
-        config_module  # reference to avoid unused import warnings
-
-
-def test_cli_overrides_config(
-    runner, mock_github_client, mock_formatter, tmp_path, monkeypatch
-):
-    """CLI options should override configuration file values."""
-    xdg_home = tmp_path / ".config"
-    app_dir = xdg_home / "gh-pr-rev-md"
-    app_dir.mkdir(parents=True)
-    (app_dir / "config.yaml").write_text(
-        """
-output_file: from_config.md
-""",
-        encoding="utf-8",
-    )
-
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            cli.main,
-            [
-                "https://github.com/owner/repo/pull/123",
-                "--token",
-                "cli_token",
-                "--include-outdated",
-                "--output-file",
-                "from_cli.md",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert Path("from_cli.md").exists()
-        assert not Path("from_config.md").exists()
-
-
-# --- Tests for hybrid git detection functionality ---
-
-
-def test_get_current_branch_pr_url_native_success():
-    """Test native git parsing successfully finding PR."""
-    with mock.patch("gh_pr_rev_md.cli.GitRepository") as mock_repo_class:
-        mock_repo = mock_repo_class.return_value
-        mock_repo.get_repository_info.return_value = ("github.com", "owner", "repo", "feature-branch")
-        
-        with mock.patch("gh_pr_rev_md.cli.GitHubClient") as mock_client:
-            mock_instance = mock.MagicMock()
-            mock_instance.find_pr_by_branch.return_value = 123
-            mock_client.return_value = mock_instance
-            
-            result = cli.get_current_branch_pr_url_native("fake-token")
-            assert result == "https://github.com/owner/repo/pull/123"
-
-
-def test_get_current_branch_pr_url_native_github_enterprise():
-    """Test native git parsing with GitHub Enterprise."""
-    with mock.patch("gh_pr_rev_md.cli.GitRepository") as mock_repo_class:
-        mock_repo = mock_repo_class.return_value
-        mock_repo.get_repository_info.return_value = ("github.enterprise.com", "company", "project", "main")
-        
-        with mock.patch("gh_pr_rev_md.cli.GitHubClient") as mock_client:
-            mock_instance = mock.MagicMock()
-            mock_instance.find_pr_by_branch.return_value = 456
-            mock_client.return_value = mock_instance
-            
-            result = cli.get_current_branch_pr_url_native("fake-token")
-            assert result == "https://github.enterprise.com/company/project/pull/456"
-
-
-def test_get_current_branch_pr_url_native_no_repo_info():
-    """Test native git parsing when repository info cannot be determined."""
-    with mock.patch("gh_pr_rev_md.cli.GitRepository") as mock_repo_class:
-        mock_repo = mock_repo_class.return_value
-        mock_repo.get_repository_info.return_value = None
-        
-        with pytest.raises(cli.GitParsingError, match="Unable to extract repository information"):
-            cli.get_current_branch_pr_url_native()
-
-
-def test_get_current_branch_pr_url_hybrid_fallback():
-    """Test hybrid approach falls back to subprocess when native parsing fails."""
-    # Mock native parsing to fail
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        # Mock subprocess approach to succeed
-        with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_subprocess") as mock_subprocess:
-            mock_subprocess.return_value = "https://github.com/owner/repo/pull/999"
-            
-            result = cli.get_current_branch_pr_url()
-            assert result == "https://github.com/owner/repo/pull/999"
-            mock_native.assert_called_once()
-            mock_subprocess.assert_called_once()
-
-
-def test_get_current_branch_pr_url_hybrid_native_success():
-    """Test hybrid approach uses native parsing when it succeeds."""
-    # Mock native parsing to succeed
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.return_value = "https://github.com/owner/repo/pull/123"
-        
-        # Mock subprocess approach (should not be called)
-        with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_subprocess") as mock_subprocess:
-            result = cli.get_current_branch_pr_url()
-            assert result == "https://github.com/owner/repo/pull/123"
-            mock_native.assert_called_once()
-            mock_subprocess.assert_not_called()
-
-
-# --- Tests for "." argument functionality ---
-
-
-def test_cli_with_period_argument_success(runner, mock_github_client, mock_formatter):
-    """Test CLI with "." argument to use current branch PR."""
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url") as mock_get_pr_url:
-        mock_get_pr_url.return_value = "https://github.com/owner/repo/pull/456"
-        
-        result = runner.invoke(cli.main, ["."])
-        
-        assert result.exit_code == 0
-        mock_get_pr_url.assert_called_once()
-        mock_github_client.get_pr_review_comments.assert_called_once_with(
-            "owner", "repo", 456, False, False
-        )
-
-
-def test_cli_with_period_argument_error(runner):
-    """Test CLI with "." argument when git operations fail."""
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url") as mock_get_pr_url:
-        mock_get_pr_url.side_effect = cli.click.BadParameter("Not in a git repository")
-        
-        result = runner.invoke(cli.main, ["."])
-        
         assert result.exit_code == 1
-        assert "Not in a git repository" in result.output
+        assert "Error fetching data from GitHub: API Error" in result.output
 
 
-def test_get_current_branch_pr_url_not_git_repo():
-    """Test get_current_branch_pr_url when not in a git repository."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = FileNotFoundError("git not found")
-            
-            with pytest.raises(cli.click.BadParameter) as exc_info:
-                cli.get_current_branch_pr_url()
-            assert "Git is not installed" in str(exc_info.value)
+# --- Tests for 'config' subcommands ---
 
 
-def test_get_current_branch_pr_url_no_git_dir():
-    """Test get_current_branch_pr_url when not in a git repository."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = subprocess.CalledProcessError(128, "git rev-parse")
-            
-            with pytest.raises(cli.click.BadParameter) as exc_info:
-                cli.get_current_branch_pr_url()
-            assert "Not in a git repository" in str(exc_info.value)
+class TestConfigCommands:
+    """Tests for the 'config' subcommands."""
+
+    def test_config_get_no_config(self, runner, monkeypatch):
+        """Test 'config get' when no config file exists."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/nonexistent-dir")
+        result = runner.invoke(cli.main, ["config", "get"])
+        assert result.exit_code == 0
+        assert "No configuration found." in result.output
+
+    def test_config_get_redacts_token(self, runner, mock_config_file):
+        """Test that 'config get' redacts the token by default."""
+        mock_config_file.write_text("token: my-secret-token", encoding="utf-8")
+        result = runner.invoke(cli.main, ["config", "get"])
+        assert result.exit_code == 0
+        assert "token: '********'" in result.output
+
+    def test_config_get_show_token(self, runner, mock_config_file):
+        """Test 'config get --show-token' displays the token."""
+        mock_config_file.write_text("token: my-secret-token", encoding="utf-8")
+        result = runner.invoke(cli.main, ["config", "get", "--show-token"])
+        assert result.exit_code == 0
+        assert "token: my-secret-token" in result.output
+
+    def test_config_check_no_token(self, runner, monkeypatch):
+        """Test 'config check' when no token is configured."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr("gh_pr_rev_md.cli.load_config", lambda: {})
+        result = runner.invoke(cli.main, ["config", "check"])
+        assert result.exit_code == 1
+        assert "FAILED: GitHub token is not configured" in result.output
+
+    def test_config_check_valid_token(self, runner, mock_github_client):
+        """Test 'config check' with a valid token."""
+        result = runner.invoke(cli.main, ["--token", "valid-token", "config", "check"])
+        assert result.exit_code == 0
+        assert "Token is valid" in result.output
+
+    def test_config_check_invalid_token(self, runner, mock_github_client):
+        """Test 'config check' with an invalid token."""
+        mock_github_client.get_authenticated_user.side_effect = (
+            github_client.GitHubAPIError("Bad credentials")
+        )
+        result = runner.invoke(
+            cli.main, ["--token", "invalid-token", "config", "check"]
+        )
+        assert result.exit_code == 1
+        assert "FAILED: Token is invalid" in result.output
 
 
-def _mock_subprocess_calls(*calls):
-    """Helper to create subprocess mock with git config fallback added."""
-    # Insert git config failure after git branch call for most tests
-    if len(calls) >= 2 and calls[0].returncode == 0 and hasattr(calls[1], 'stdout'):
-        # Insert git config failure after first two successful calls (rev-parse, branch)
-        calls_with_config = [
-            calls[0],  # git rev-parse
-            calls[1],  # git branch  
-            subprocess.CalledProcessError(1, "git config"),  # git config fails (fallback to origin)
-            *calls[2:]  # remaining calls
-        ]
-        return calls_with_config
-    return calls
+# --- Tests for default command and argument passing ---
 
 
-def test_get_current_branch_pr_url_no_origin_remote():
-    """Test get_current_branch_pr_url when no origin remote is configured."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = _mock_subprocess_calls(
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout="main"),  # git branch succeeds
-                subprocess.CalledProcessError(1, "git remote get-url"),  # git remote get-url fails
-            )
-            
-            with pytest.raises(cli.click.BadParameter) as exc_info:
-                cli.get_current_branch_pr_url()
-            assert "No 'origin' remote found" in str(exc_info.value)
+def test_default_command_is_fetch(runner, mock_github_client):
+    """Test that running the CLI without a command defaults to 'fetch'."""
+    result = runner.invoke(cli.main, ["https://github.com/owner/repo/pull/123"])
+    assert result.exit_code == 0
+    mock_github_client.get_pr_review_comments.assert_called_once()
 
 
-def test_get_current_branch_pr_url_invalid_remote_url():
-    """Test get_current_branch_pr_url with invalid remote URL."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = _mock_subprocess_calls(
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout="main"),  # git branch succeeds
-                mock.MagicMock(returncode=0, stdout="https://gitlab.com/owner/repo.git"),  # invalid remote
-            )
-            
-            with pytest.raises(cli.click.BadParameter) as exc_info:
-                cli.get_current_branch_pr_url()
-            assert "Could not parse remote URL" in str(exc_info.value)
+def test_no_pr_url_error(runner):
+    """Test that 'fetch' command exits if no PR_URL is provided."""
+    result = runner.invoke(cli.main, ["fetch"])
+    assert result.exit_code == 2  # click.UsageError
+    assert "Missing argument 'PR_URL'" in result.output
 
 
-def test_get_current_branch_pr_url_success_with_api():
-    """Test get_current_branch_pr_url successfully finding PR via GitHub API."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = _mock_subprocess_calls(
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout="feature-branch"),  # git branch succeeds
-                mock.MagicMock(returncode=0, stdout="https://github.com/owner/repo.git"),  # remote URL
-            )
-            
-            with mock.patch("gh_pr_rev_md.cli.GitHubClient") as mock_client:
-                mock_instance = mock.MagicMock()
-                mock_instance.find_pr_by_branch.return_value = 123
-                mock_client.return_value = mock_instance
-                
-                result = cli.get_current_branch_pr_url("fake-token")
-                assert result == "https://github.com/owner/repo/pull/123"
-
-
-def test_get_current_branch_pr_url_success_with_gh_cli():
-    """Test get_current_branch_pr_url successfully finding PR via GitHub CLI."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = _mock_subprocess_calls(
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout="feature-branch"),  # git branch succeeds
-                mock.MagicMock(returncode=0, stdout="https://github.com/owner/repo.git"),  # remote URL
-                mock.MagicMock(returncode=0, stdout="https://github.com/owner/repo/pull/456"),  # gh pr view succeeds
-            )
-            
-            result = cli.get_current_branch_pr_url()
-            assert result == "https://github.com/owner/repo/pull/456"
-
-
-def test_get_current_branch_pr_url_no_pr_found():
-    """Test get_current_branch_pr_url when no PR is found for the branch."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = _mock_subprocess_calls(
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout="feature-branch"),  # git branch succeeds
-                mock.MagicMock(returncode=0, stdout="https://github.com/owner/repo.git"),  # remote URL
-                subprocess.CalledProcessError(1, "gh pr view"),  # gh pr view fails
-            )
-            
-            with pytest.raises(cli.click.BadParameter) as exc_info:
-                cli.get_current_branch_pr_url()
-            assert "No open pull request found" in str(exc_info.value)
-
-
-def test_get_current_branch_pr_url_detached_head():
-    """Test get_current_branch_pr_url when in detached HEAD state."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout=""),  # git branch returns empty (detached HEAD)
-            ]
-            
-            with pytest.raises(cli.click.BadParameter) as exc_info:
-                cli.get_current_branch_pr_url()
-            assert "Could not determine current branch" in str(exc_info.value)
-
-
-def test_get_current_branch_pr_url_ssh_remote():
-    """Test get_current_branch_pr_url with SSH remote URL."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = _mock_subprocess_calls(
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout="feature-branch"),  # git branch succeeds
-                mock.MagicMock(returncode=0, stdout="git@github.com:owner/repo.git"),  # SSH remote URL
-            )
-            
-            with mock.patch("gh_pr_rev_md.cli.GitHubClient") as mock_client:
-                mock_instance = mock.MagicMock()
-                mock_instance.find_pr_by_branch.return_value = 789
-                mock_client.return_value = mock_instance
-                
-                result = cli.get_current_branch_pr_url("fake-token")
-                assert result == "https://github.com/owner/repo/pull/789"
-
-
-def test_get_current_branch_pr_url_api_fallback_to_gh_cli():
-    """Test get_current_branch_pr_url falls back to GitHub CLI when API fails."""
-    # Mock native parsing to fail, triggering subprocess fallback
-    with mock.patch("gh_pr_rev_md.cli.get_current_branch_pr_url_native") as mock_native:
-        mock_native.side_effect = cli.GitParsingError("Native parsing failed")
-        
-        with mock.patch("subprocess.run") as mock_run:
-            mock_run.side_effect = _mock_subprocess_calls(
-                mock.MagicMock(returncode=0),  # git rev-parse succeeds
-                mock.MagicMock(returncode=0, stdout="feature-branch"),  # git branch succeeds
-                mock.MagicMock(returncode=0, stdout="https://github.com/owner/repo.git"),  # remote URL
-                mock.MagicMock(returncode=0, stdout="https://github.com/owner/repo/pull/999"),  # gh pr view succeeds
-            )
-            
-            with mock.patch("gh_pr_rev_md.cli.GitHubClient") as mock_client:
-                mock_instance = mock.MagicMock()
-                mock_instance.find_pr_by_branch.side_effect = github_client.GitHubAPIError("API failed")
-                mock_client.return_value = mock_instance
-                
-                result = cli.get_current_branch_pr_url("fake-token")
-                assert result == "https://github.com/owner/repo/pull/999"
+def test_no_command_error(runner):
+    """Test that running the CLI with no args shows help for the main command."""
+    result = runner.invoke(cli.main, [])
+    assert result.exit_code == 2
+    assert "Usage: main [OPTIONS] COMMAND [ARGS]..." in result.output


### PR DESCRIPTION
This commit introduces several new features related to configuration:

- A `config get` command to display the current configuration. The GitHub token is redacted by default for security, but can be shown with `--show-token`.
- A `config check` command to validate the configuration. This command checks for the presence of a GitHub token and verifies its validity by making a test call to the GitHub API.
- The interactive configuration setup (`--config-set`) now includes an option to set file output as the default behavior.

To support these new commands, the CLI has been refactored to use `click.group` with a `DefaultGroup` class to maintain backward compatibility. The test suite has been updated to cover the new functionality.