### PR TITLE
feat(cli): add GitHub Enterprise support

### DIFF
--- a/gh_pr_rev_md/cli.py
+++ b/gh_pr_rev_md/cli.py
@@ -87,13 +87,13 @@ def get_current_branch_pr_url_subprocess(token: Optional[str] = None) -> str:
         repo = None
         # Handle both SSH and HTTPS URLs for GitHub or GitHub Enterprise
         if remote_url.startswith("git@"):
-            m = re.match(r"git@([^:]+):([^/]+)/([^/]+?)(?:\.git)?$", remote_url)
-            if m:
-                host, owner, repo = m.groups()
+            pattern = r"git@([^:]+):([^/]+)/([^/]+?)(?:\.git)?$"
         else:
-            m = re.match(r"https://([^/]+)/([^/]+)/([^/]+?)(?:\.git)?$", remote_url)
-            if m:
-                host, owner, repo = m.groups()
+            pattern = r"https://([^/]+)/([^/]+)/([^/]+?)(?:\.git)?$"
+
+        match = re.match(pattern, remote_url)
+        if match:
+            host, owner, repo = match.groups()
         
         if not host or 'github' not in host.lower():
             raise click.BadParameter(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,14 @@ def test_parse_pr_url_valid():
             "https://github.com/owner-dash/repo_under/pull/456",
             ("owner-dash", "repo_under", 456),
         ),
+        (
+            "https://github.enterprise.com/org/repo/pull/42",
+            ("org", "repo", 42),
+        ),
+        (
+            "https://github.internal.local/org/repo/pull/7?foo=bar#frag",
+            ("org", "repo", 7),
+        ),
     ]
 
     for url, expected in test_cases:


### PR DESCRIPTION
- Accept GHE hosts in PR URLs (parse_pr_url)
- Parse SSH/HTTPS remotes generically (host/owner/repo), support GHE
- Use correct host for API-discovered PR URL in subprocess flow
- Add tests for GHE URLs and query/fragment tolerance
