### PR TITLE
feat(cli): add --create-dirs to write nested output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options:
 - `--include-outdated`: Include outdated review comments (on previous versions of the diff)
 - `--output` / `-o`: Save to auto-generated file name
 - `--output-file <path>`: Save to provided file path
+- `--create-dirs`: Create parent directories for `--output-file`
 
 URL format must be: `https://github.com/<owner>/<repo>/pull/<number>`
 

--- a/gh_pr_rev_md/cli.py
+++ b/gh_pr_rev_md/cli.py
@@ -332,6 +332,12 @@ def _interactive_config_setup() -> None:
 @click.option(
     "--output-file", type=str, default=None, help="Save output to specified file"
 )
+@click.option(
+    "--create-dirs",
+    is_flag=True,
+    default=False,
+    help="Create parent directories when using --output-file",
+)
 def main(
     pr_url: Optional[str],
     token: Optional[str],
@@ -340,6 +346,7 @@ def main(
     include_outdated: Optional[bool],
     output: Optional[bool],
     output_file: Optional[str],
+    create_dirs: bool,
 ):
     """Fetch GitHub PR review comments and output as markdown.
 
@@ -422,6 +429,8 @@ def main(
             file_path = Path(filename)
 
             try:
+                if create_dirs and file_path.parent != Path('.'):
+                    file_path.parent.mkdir(parents=True, exist_ok=True)
                 file_path.write_text(markdown_output, encoding="utf-8")
                 click.echo(f"Output saved to: {file_path.absolute()}")
             except (OSError, PermissionError) as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,8 +264,31 @@ def test_main_file_write_nested_directory(runner, mock_github_client, mock_forma
         )
 
         # This should fail because parent directories don't exist
-        assert result.exit_code == 1
-        assert "Error writing to file" in result.output
+    assert result.exit_code == 1
+    assert "Error writing to file" in result.output
+
+
+def test_main_file_write_nested_directory_with_create_dirs(
+    runner, mock_github_client, mock_formatter
+):
+    """Test file output to nested directory path when --create-dirs is used."""
+    with runner.isolated_filesystem():
+        nested_filename = "nested/dir/output.md"
+
+        result = runner.invoke(
+            cli.main,
+            [
+                "https://github.com/owner/repo/pull/123",
+                "--token",
+                "test_token",
+                "--output-file",
+                nested_filename,
+                "--create-dirs",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert Path(nested_filename).exists()
 
 
 def test_main_include_flags_integration(runner, mock_github_client, mock_formatter):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,8 +264,8 @@ def test_main_file_write_nested_directory(runner, mock_github_client, mock_forma
         )
 
         # This should fail because parent directories don't exist
-    assert result.exit_code == 1
-    assert "Error writing to file" in result.output
+        assert result.exit_code == 1
+        assert "Error writing to file" in result.output
 
 
 def test_main_file_write_nested_directory_with_create_dirs(


### PR DESCRIPTION
- New flag to create parent directories for --output-file
- Tests cover nested directory success and default failure
- README documents the new option
