### PR TITLE
chore: switch documentation references from black to ruff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ The output will be a markdown formatted list of all review comments on the pull 
 
 ## Code Style
 
-This project uses `ruff` for code formatting and linting for Python. Before committing any changes, please format your code with:
+This project uses `ruff` for code formatting and linting for Python. Before committing any changes, please lint and auto-fix your code with:
 
 ```bash
 uv run ruff check --fix .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,10 @@ The output will be a markdown formatted list of all review comments on the pull 
 
 ## Code Style
 
-This project uses the `black` code formatter for Python. Before committing any changes, please format your code with:
+This project uses `ruff` for code formatting and linting for Python. Before committing any changes, please format your code with:
 
 ```bash
-black .
+uv run ruff check --fix .
 ```
 
 ## Architecture


### PR DESCRIPTION
Update AGENTS.md to reference ruff instead of black for code formatting and linting, aligning with the project's current tooling setup.

🤖 Generated with [Claude Code](https://claude.ai/code)