### PR TITLE
feat(cli): display help when no args provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ If you don’t set a token, unauthenticated requests are limited (~60/hour) and 
 ## CLI Usage
 
 ```bash
-gh-pr-rev-md [OPTIONS] PR_URL
+gh-pr-rev-md [OPTIONS] [PR_URL]
 ```
+
+Running the command without any arguments displays this help message.
 
 Options:
 - `--token` (env: `GITHUB_TOKEN`): GitHub token for higher rate limits


### PR DESCRIPTION
## Summary
- show CLI help when command is invoked with no arguments or options
- document default help behavior in README

## Testing
- `black gh_pr_rev_md/cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be40a8c2c88321af8a6ebdb268c86c