### PR TITLE
Add config-print command with token redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ gh-pr-rev-md [OPTIONS] PR_URL
 Options:
 - `--token` (env: `GITHUB_TOKEN`): GitHub token for higher rate limits
 - `--config-set`: Interactive setup to write an XDG config file
+- `--config-print`: Display current configuration (token redacted)
 - `--include-resolved`: Include resolved review comments
 - `--include-outdated`: Include outdated review comments (on previous versions of the diff)
 - `--output` / `-o`: Save to auto-generated file name
@@ -124,6 +125,12 @@ Create/update interactively:
 
 ```bash
 gh-pr-rev-md --config-set
+```
+
+Print current configuration:
+
+```bash
+gh-pr-rev-md --config-print
 ```
 
 ## Output format

--- a/gh_pr_rev_md/cli.py
+++ b/gh_pr_rev_md/cli.py
@@ -152,7 +152,7 @@ def get_current_branch_pr_url_native(token: Optional[str] = None) -> str:
             raise GitParsingError("Unable to extract repository information")
 
         host, owner, repo_name, branch = repo_info
-        
+
         return _resolve_pr_url(owner, repo_name, branch, host, token)
     except GitParsingError as e:
         # Re-raise as GitParsingError so the hybrid function can catch it
@@ -172,7 +172,9 @@ def parse_pr_url(url: str) -> Tuple[str, str, int]:
     return owner, repo, int(pr_number)
 
 
-def _resolve_pr_url(owner: str, repo: str, branch: str, host: str, token: Optional[str]) -> str:
+def _resolve_pr_url(
+    owner: str, repo: str, branch: str, host: str, token: Optional[str]
+) -> str:
     """Resolve PR URL by trying GitHub API first, then gh CLI; raise on failure."""
     # Try to find PR using GitHub API if token provided
     if token:
@@ -188,7 +190,18 @@ def _resolve_pr_url(owner: str, repo: str, branch: str, host: str, token: Option
     # Try to find the PR for the current branch using GitHub CLI
     try:
         result = subprocess.run(  # nosec B603 B607
-            ["gh", "pr", "view", branch, "--repo", f"{owner}/{repo}", "--json", "url", "--jq", ".url"],
+            [
+                "gh",
+                "pr",
+                "view",
+                branch,
+                "--repo",
+                f"{owner}/{repo}",
+                "--json",
+                "url",
+                "--jq",
+                ".url",
+            ],
             capture_output=True,
             text=True,
             check=True,
@@ -297,6 +310,22 @@ def _interactive_config_setup() -> None:
     click.echo(f"Config written to: {config_path}")
 
 
+def _print_config() -> None:
+    """Print current configuration with token redacted."""
+    config = load_config()
+    if not config:
+        click.echo("No configuration found.")
+        return
+    redacted = dict(config)
+    token = redacted.get("token")
+    if token:
+        if len(token) > 6:
+            redacted["token"] = token[:3] + "*" * (len(token) - 6) + token[-3:]
+        else:
+            redacted["token"] = token
+    click.echo(yaml.safe_dump(redacted, sort_keys=False).strip())
+
+
 @click.command()
 @click.argument("pr_url", required=False)
 @click.option(
@@ -338,10 +367,17 @@ def _interactive_config_setup() -> None:
     default=False,
     help="Create parent directories when using --output-file",
 )
+@click.option(
+    "--config-print",
+    is_flag=True,
+    default=False,
+    help="Print current configuration then exit",
+)
 def main(
     pr_url: Optional[str],
     token: Optional[str],
     config_set: bool,
+    config_print: bool,
     include_resolved: Optional[bool],
     include_outdated: Optional[bool],
     output: Optional[bool],
@@ -367,6 +403,10 @@ def main(
         except (click.Abort, OSError, yaml.YAMLError) as e:
             click.echo(f"Error during config setup: {e}", err=True)
             sys.exit(1)
+
+    if config_print:
+        _print_config()
+        sys.exit(0)
 
     # Load XDG YAML config and merge with CLI/env values (CLI/env > config > defaults)
     config = load_config()
@@ -429,7 +469,7 @@ def main(
             file_path = Path(filename)
 
             try:
-                if create_dirs and file_path.parent != Path('.'):
+                if create_dirs and file_path.parent != Path("."):
                     file_path.parent.mkdir(parents=True, exist_ok=True)
                 file_path.write_text(markdown_output, encoding="utf-8")
                 click.echo(f"Output saved to: {file_path.absolute()}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,6 +493,34 @@ output_file: from_config.md
         assert not Path("from_config.md").exists()
 
 
+def test_config_print_redacts_token(runner, tmp_path, monkeypatch):
+    """--config-print shows config with token redacted."""
+    xdg_home = tmp_path / ".config"
+    app_dir = xdg_home / "gh-pr-rev-md"
+    app_dir.mkdir(parents=True)
+    (app_dir / "config.yaml").write_text(
+        yaml.safe_dump({"token": "abc123def456", "include_resolved": True}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+
+    result = runner.invoke(cli.main, ["--config-print"])
+    assert result.exit_code == 0
+    assert "token: abc******456" in result.output
+    assert "include_resolved: true" in result.output
+
+
+def test_config_print_no_config(runner, tmp_path, monkeypatch):
+    """--config-print handles missing configuration."""
+    xdg_home = tmp_path / ".config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+
+    result = runner.invoke(cli.main, ["--config-print"])
+    assert result.exit_code == 0
+    assert "No configuration found." in result.output
+
+
 # --- Tests for hybrid git detection functionality ---
 
 


### PR DESCRIPTION
## Summary
- add `--config-print` flag to display current configuration
- redact GitHub token to first and last three characters
- document new flag and add tests

## Testing
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be408fb1d48321962f002323a1a444