### PR TITLE
Fix PR URL parsing to reject trailing path segments

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,8 @@ def test_parse_pr_url_valid():
         "https://github.com/owner/repo/pull/",  # Missing PR number
         "https://github.com/owner/pull/123",  # Missing repo
         "https://github.com/owner/repo/issues/123",  # Issues instead of pull
+        "https://github.com/owner/repo/pull/123/",  # Trailing slash
+        "https://github.com/owner/repo/pull/123/commits",  # Extra path segment
         "https://gitlab.com/owner/repo/pull/123",  # Wrong domain
         "invalid-url",  # Completely invalid
         "",  # Empty string


### PR DESCRIPTION
## Summary
- ensure `parse_pr_url` validates the whole PR URL instead of accepting extra path segments
- add tests for PR URLs with trailing slash or additional path segments

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be44f3492c8321bbd170053032e52e